### PR TITLE
Clarify docs and centralize query parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,4 +37,8 @@ cargo test
 cargo tarpaulin --timeout 120 --out Lcov
 ```
 
+The ports above are examples; when running behind Tor the [onion guide](docs/onion.md)
+uses `3000/3001` to match the `torrc` example. Choose values that align across
+your configuration.
+
 See [docs/onion.md](docs/onion.md) for Tor deployment details.

--- a/docs/onion.md
+++ b/docs/onion.md
@@ -14,23 +14,31 @@ HiddenServicePort 80 127.0.0.1:3000
 HiddenServicePort 443 127.0.0.1:3001
 ```
 
-Restart `tor`. The generated hostname will be placed in the `HiddenServiceDir`.
+Restart `tor`. The generated onion hostname will be written to
+`HiddenServiceDir/hostname`.
 
 ## Binding stonr services
 
-stonr reads several environment variables to bind its services:
+stonr requires a few environment variables—none have built-in defaults:
 
-- `BIND_HTTP` – HTTP listening address (default `127.0.0.1:3000`)
-- `BIND_WS` – WebSocket listening address (default `127.0.0.1:3001`)
-- `TOR_SOCKS` – Tor SOCKS proxy address (default `127.0.0.1:9050`)
+- `STORE_ROOT` – directory to store events
+- `BIND_HTTP` – HTTP listening address
+- `BIND_WS` – WebSocket listening address
+- `TOR_SOCKS` – Tor SOCKS proxy address
 
-Run `stonr` with these variables set to match the ports configured in `torrc`:
+Create a `.env` file matching the ports in your `torrc`:
 
-```bash
-BIND_HTTP=127.0.0.1:3000 \
-BIND_WS=127.0.0.1:3001 \
-TOR_SOCKS=127.0.0.1:9050 \
-stonr
+```
+STORE_ROOT=/srv/stonr
+BIND_HTTP=127.0.0.1:3000
+BIND_WS=127.0.0.1:3001
+TOR_SOCKS=127.0.0.1:9050
 ```
 
-Now stonr will accept connections from Tor via the hidden service.
+Start the relay using this configuration:
+
+```bash
+stonr serve --env .env
+```
+
+stonr will now accept connections from Tor via the hidden service.


### PR DESCRIPTION
## Summary
- document required env vars and sample `.env` for Tor onion setup
- clarify port examples in README and crosslink onion guide
- factor shared filter parsing into `Query::from_value` and add novice-friendly comments across server, WS, storage, and siphon modules

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68bf53558c5883209b9fa70efc055d47