### PR TITLE
Add GitHub Action to build release binary

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,27 @@
+name: Build release binary
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build release binary
+        run: cargo build --locked --release
+
+      - name: Upload release binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: stonr-linux-amd64
+          path: target/release/stonr
+          if-no-files-found: error


### PR DESCRIPTION
## Summary
- add a pull request workflow that builds the project in release mode
- upload the compiled `stonr` binary as a downloadable artifact

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68db6bed5ed083209f9027c73e646a54