### PR TITLE
Build musl release binary in CI

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -16,12 +16,20 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install MUSL toolchain dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+
+      - name: Add MUSL compilation target
+        run: rustup target add x86_64-unknown-linux-musl
+
       - name: Build release binary
-        run: cargo build --locked --release
+        run: cargo build --locked --release --target x86_64-unknown-linux-musl
 
       - name: Upload release binary
         uses: actions/upload-artifact@v4
         with:
-          name: stonr-linux-amd64
-          path: target/release/stonr
+          name: stonr-linux-amd64-musl
+          path: target/x86_64-unknown-linux-musl/release/stonr
           if-no-files-found: error


### PR DESCRIPTION
## Summary
- install MUSL tooling and add the x86_64-unknown-linux-musl target in the release workflow
- build and upload the MUSL-based binary so the artifact works on NixOS

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db7db6aa5c8320b73c54745293395f