### PR TITLE
Restore glibc artifact alongside MUSL build

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -16,12 +16,30 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Build release binary
+      - name: Build glibc release binary
         run: cargo build --locked --release
 
-      - name: Upload release binary
+      - name: Upload glibc release binary
         uses: actions/upload-artifact@v4
         with:
           name: stonr-linux-amd64
           path: target/release/stonr
+          if-no-files-found: error
+
+      - name: Install MUSL toolchain dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+
+      - name: Add MUSL compilation target
+        run: rustup target add x86_64-unknown-linux-musl
+
+      - name: Build MUSL release binary
+        run: cargo build --locked --release --target x86_64-unknown-linux-musl
+
+      - name: Upload MUSL release binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: stonr-linux-amd64-musl
+          path: target/x86_64-unknown-linux-musl/release/stonr
           if-no-files-found: error


### PR DESCRIPTION
## Summary
- build the default glibc-targeted binary in CI before compiling the MUSL binary
- upload both the glibc and MUSL artifacts so the workflow still exposes the original download

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db7db6aa5c8320b73c54745293395f