### PR TITLE
Add CLI commands to manage upstream mirrors

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -4,10 +4,14 @@ on:
   pull_request:
     branches:
       - '**'
+  release:
+    types: [published]
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout repository
@@ -16,12 +20,60 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Build release binary
+      - name: Build glibc release binary
         run: cargo build --locked --release
 
-      - name: Upload release binary
+      - name: Install MUSL toolchain dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+
+      - name: Add MUSL compilation target
+        run: rustup target add x86_64-unknown-linux-musl
+
+      - name: Build MUSL release binary
+        run: cargo build --locked --release --target x86_64-unknown-linux-musl
+
+      - name: Prepare distributable archives
+        run: |
+          install -d dist/glibc dist/musl
+          cp target/release/stonr dist/glibc/stonr
+          tar -C dist/glibc -czf dist/stonr-linux-amd64.tar.gz stonr
+          cp target/x86_64-unknown-linux-musl/release/stonr dist/musl/stonr
+          tar -C dist/musl -czf dist/stonr-linux-amd64-musl.tar.gz stonr
+
+      - name: Upload glibc artifact
         uses: actions/upload-artifact@v4
         with:
           name: stonr-linux-amd64
-          path: target/release/stonr
+          path: dist/stonr-linux-amd64.tar.gz
           if-no-files-found: error
+
+      - name: Upload MUSL artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: stonr-linux-amd64-musl
+          path: dist/stonr-linux-amd64-musl.tar.gz
+          if-no-files-found: error
+
+      - name: Attach glibc artifact to release
+        if: github.event_name == 'release'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: dist/stonr-linux-amd64.tar.gz
+          asset_name: stonr-linux-amd64.tar.gz
+          asset_content_type: application/gzip
+
+      - name: Attach MUSL artifact to release
+        if: github.event_name == 'release'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: dist/stonr-linux-amd64-musl.tar.gz
+          asset_name: stonr-linux-amd64-musl.tar.gz
+          asset_content_type: application/gzip

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ stonr serve --env .env
 curl "http://localhost:7777/query?authors=npub1&kinds=1"
 ```
 
+Running any command will bootstrap `.env` with sensible defaults if it is missing,
+placing `stonr-data/` next to the config file.
+
 See [docs/api.md](docs/api.md) for HTTP and WebSocket details,
 [docs/mirroring.md](docs/mirroring.md) for mirroring setups, and
 [docs/onion.md](docs/onion.md) for Tor deployment.
@@ -69,6 +72,16 @@ FILTER_KINDS=1
 FILTER_SINCE_MODE=cursor
 ```
 
+## Mirroring upstream relays
+
+Set `RELAYS_UPSTREAM` to a comma-separated list of relay URLs in your `.env`
+file. Optional `FILTER_AUTHORS`, `FILTER_KINDS`, `FILTER_TAG_T`, and
+`FILTER_SINCE_MODE` values narrow the subscription. After updating the config,
+run `stonr serve --env .env` to connect and start ingesting mirrored events. You
+can also manage entries with `stonr mirror add <url>` (which verifies the relay
+before saving it) and `stonr mirror remove <url>`. See
+[docs/mirroring.md](docs/mirroring.md) for detailed examples.
+
 ## CLI
 
 ```
@@ -77,6 +90,8 @@ stonr ingest events/*.json
 stonr reindex --env .env
 stonr serve --env .env
 stonr verify --env .env --sample 1000
+stonr mirror add wss://relay.example
+stonr mirror remove wss://relay.example
 ```
 
 ## Build and Test

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -1,0 +1,9 @@
+# Release checklist
+
+- [ ] `stonr init` succeeds from a clean checkout and creates a default `.env`.
+- [ ] Default `.env` points `STORE_ROOT` to `stonr-data` next to the config file.
+- [ ] `stonr -v` prints the crate version.
+- [ ] Mirroring only activates when `RELAYS_UPSTREAM` is set.
+- [ ] `stonr mirror add <url>` connects successfully before updating `RELAYS_UPSTREAM`.
+- [ ] `stonr mirror remove <url>` removes the relay from the configuration.
+- [ ] Update docs if configuration variables change.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1,0 +1,23 @@
+# stonr Spec
+
+## Configuration bootstrap
+- The CLI accepts an `--env` flag (default `.env`).
+- When the referenced `.env` file is missing, stonr creates it with sane defaults:
+  - `STORE_ROOT` pointing to `stonr-data` beside the env file
+  - `BIND_HTTP=127.0.0.1:7777`
+  - `BIND_WS=127.0.0.1:7778`
+  - `VERIFY_SIG=0`
+  - empty `RELAYS_UPSTREAM`, `FILTER_AUTHORS`, `FILTER_KINDS`, `FILTER_TAG_T`, and `TOR_SOCKS`
+  - `FILTER_SINCE_MODE=cursor`
+- After bootstrap the CLI loads settings from the env file for every subcommand.
+
+## CLI behaviour
+- `stonr init` ensures the storage directory structure exists.
+- `stonr serve` reuses the same settings, starting mirroring only when `RELAYS_UPSTREAM` has entries.
+- `stonr -v` prints the package version.
+- `stonr mirror add <url>` verifies the upstream relay is reachable before adding it to `RELAYS_UPSTREAM`.
+- `stonr mirror remove <url>` removes the relay from `RELAYS_UPSTREAM`.
+
+## Mirroring
+- Configure mirroring via `RELAYS_UPSTREAM` and optional `FILTER_*` variables in the `.env` file.
+- `stonr serve` connects to each upstream relay, applying the filters and keeping cursors per relay.

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,20 +4,32 @@
 
 mod config;
 mod event;
-mod server;
 mod mirror;
+mod server;
 mod storage;
 mod ws;
 
-use std::net::SocketAddr;
+use std::{
+    fs,
+    net::SocketAddr,
+    path::{Path, PathBuf},
+};
 
+use anyhow::bail;
 use clap::{Parser, Subcommand};
 use config::Settings;
 use storage::Store;
 
 /// Command line interface entry point.
 #[derive(Parser)]
-#[command(name = "stonr", author, version, about = "File-backed Nostr relay")]
+#[command(
+    name = "stonr",
+    author,
+    version,
+    about = "File-backed Nostr relay",
+    short_flag = 'v',
+    long_flag = "version"
+)]
 struct Cli {
     /// Path to the `.env` configuration file.
     #[arg(long, default_value = ".env")]
@@ -47,52 +59,165 @@ enum Commands {
         #[arg(long, default_value_t = 1000)]
         sample: usize,
     },
+    /// Manage upstream mirror configuration.
+    Mirror {
+        #[command(subcommand)]
+        action: MirrorAction,
+    },
+}
+
+/// Operations available under `stonr mirror`.
+#[derive(Subcommand)]
+enum MirrorAction {
+    /// Add an upstream relay after verifying connectivity.
+    Add { url: String },
+    /// Remove an upstream relay from the configuration.
+    Remove { url: String },
 }
 
 /// Execute the selected CLI subcommand.
 async fn run(cli: Cli) -> anyhow::Result<()> {
+    ensure_env_file(&cli.env)?;
     let cfg = Settings::from_env(&cli.env)?;
-    let store = Store::new(cfg.store_root.clone(), cfg.verify_sig);
     match cli.command {
-        Commands::Init => {
-            // Create the on-disk directory structure.
-            store.init()?;
+        Commands::Mirror { action } => {
+            handle_mirror(action, &cli.env, &cfg).await?;
         }
-        Commands::Ingest { files } => {
-            // Load each JSON file and store it if not already present.
-            for f in files {
-                let data = std::fs::read_to_string(&f)?;
-                let ev: event::Event = serde_json::from_str(&data)?;
-                store.ingest(&ev)?;
+        command => {
+            let store = Store::new(cfg.store_root.clone(), cfg.verify_sig);
+            match command {
+                Commands::Init => {
+                    // Create the on-disk directory structure.
+                    store.init()?;
+                }
+                Commands::Ingest { files } => {
+                    // Load each JSON file and store it if not already present.
+                    for f in files {
+                        let data = std::fs::read_to_string(&f)?;
+                        let ev: event::Event = serde_json::from_str(&data)?;
+                        store.ingest(&ev)?;
+                    }
+                }
+                Commands::Reindex => {
+                    // Rebuild indexes and latest pointers from existing events.
+                    store.reindex()?;
+                }
+                Commands::Serve => {
+                    // Initialize storage then start HTTP and WS servers.
+                    store.init()?;
+                    let http_addr: SocketAddr = cfg.bind_http.as_str().parse()?;
+                    let ws_addr: SocketAddr = cfg.bind_ws.as_str().parse()?;
+                    // If upstream relays are configured, start mirroring in the background.
+                    if !cfg.relays_upstream.is_empty() {
+                        let store_clone = store.clone();
+                        let cfg_clone = cfg.clone();
+                        tokio::spawn(async move { mirror::run(cfg_clone, store_clone).await });
+                    }
+                    let store_http = store.clone();
+                    let store_ws = store.clone();
+                    tokio::try_join!(
+                        server::serve_http(http_addr, store_http, std::future::pending()),
+                        ws::serve_ws(ws_addr, store_ws, std::future::pending())
+                    )?;
+                }
+                Commands::Verify { sample } => {
+                    // Randomly verify Schnorr signatures for `sample` events.
+                    store.verify_sample(sample)?;
+                }
+                Commands::Mirror { .. } => unreachable!(),
             }
-        }
-        Commands::Reindex => {
-            // Rebuild indexes and latest pointers from existing events.
-            store.reindex()?;
-        }
-        Commands::Serve => {
-            // Initialize storage then start HTTP and WS servers.
-            store.init()?;
-            let http_addr: SocketAddr = cfg.bind_http.parse()?;
-            let ws_addr: SocketAddr = cfg.bind_ws.parse()?;
-            // If upstream relays are configured, start mirroring in the background.
-            if !cfg.relays_upstream.is_empty() {
-                let store_clone = store.clone();
-                let cfg_clone = cfg.clone();
-                tokio::spawn(async move { mirror::run(cfg_clone, store_clone).await });
-            }
-            let store_http = store.clone();
-            let store_ws = store.clone();
-            tokio::try_join!(
-                server::serve_http(http_addr, store_http, std::future::pending()),
-                ws::serve_ws(ws_addr, store_ws, std::future::pending())
-            )?;
-        }
-        Commands::Verify { sample } => {
-            // Randomly verify Schnorr signatures for `sample` events.
-            store.verify_sample(sample)?;
         }
     }
+    Ok(())
+}
+
+/// Create a default `.env` file if one is not already present at `path`.
+fn ensure_env_file(path: &str) -> anyhow::Result<()> {
+    let env_path = Path::new(path);
+    if env_path.exists() {
+        return Ok(());
+    }
+    if let Some(parent) = env_path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)?;
+        }
+    }
+    let base_dir = match env_path.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => parent.to_path_buf(),
+        _ => std::env::current_dir()?,
+    };
+    let store_root = base_dir.join("stonr-data");
+    let mut content = String::new();
+    content.push_str(&format!("STORE_ROOT={}\n", display_path(&store_root)));
+    content.push_str("BIND_HTTP=127.0.0.1:7777\n");
+    content.push_str("BIND_WS=127.0.0.1:7778\n");
+    content.push_str("VERIFY_SIG=0\n");
+    content.push_str("RELAYS_UPSTREAM=\n");
+    content.push_str("FILTER_AUTHORS=\n");
+    content.push_str("FILTER_KINDS=\n");
+    content.push_str("FILTER_TAG_T=\n");
+    content.push_str("FILTER_SINCE_MODE=cursor\n");
+    content.push_str("TOR_SOCKS=\n");
+    fs::write(env_path, content)?;
+    Ok(())
+}
+
+fn display_path(path: &PathBuf) -> String {
+    path.to_string_lossy().into_owned()
+}
+
+async fn handle_mirror(action: MirrorAction, env_path: &str, cfg: &Settings) -> anyhow::Result<()> {
+    match action {
+        MirrorAction::Add { url } => add_mirror(env_path, cfg, url).await?,
+        MirrorAction::Remove { url } => remove_mirror(env_path, cfg, url)?,
+    }
+    Ok(())
+}
+
+async fn add_mirror(env_path: &str, cfg: &Settings, url: String) -> anyhow::Result<()> {
+    if cfg.relays_upstream.iter().any(|existing| existing == &url) {
+        bail!("mirror already configured: {url}");
+    }
+    mirror::test_connection(&url, cfg.tor_socks.as_deref()).await?;
+    let mut relays = cfg.relays_upstream.clone();
+    relays.push(url);
+    write_relays_to_env(env_path, &relays)?;
+    Ok(())
+}
+
+fn remove_mirror(env_path: &str, cfg: &Settings, url: String) -> anyhow::Result<()> {
+    let mut relays = cfg.relays_upstream.clone();
+    let before = relays.len();
+    relays.retain(|existing| existing != &url);
+    if relays.len() == before {
+        bail!("mirror not configured: {url}");
+    }
+    write_relays_to_env(env_path, &relays)?;
+    Ok(())
+}
+
+fn write_relays_to_env(env_path: &str, relays: &[String]) -> anyhow::Result<()> {
+    let content = fs::read_to_string(env_path)?;
+    let relays_joined = relays.join(",");
+    let mut new_content = String::new();
+    let mut replaced = false;
+    for line in content.lines() {
+        if line.starts_with("RELAYS_UPSTREAM=") {
+            new_content.push_str(&format!("RELAYS_UPSTREAM={relays_joined}\n"));
+            replaced = true;
+        } else {
+            new_content.push_str(line);
+            new_content.push('\n');
+        }
+    }
+    if !replaced {
+        if !new_content.is_empty() && !new_content.ends_with('\n') {
+            new_content.push('\n');
+        }
+        new_content.push_str(&format!("RELAYS_UPSTREAM={relays_joined}\n"));
+    }
+    fs::write(env_path, new_content)?;
+    std::env::set_var("RELAYS_UPSTREAM", relays_joined);
     Ok(())
 }
 
@@ -107,9 +232,11 @@ async fn main() -> anyhow::Result<()> {
 mod tests {
     use super::*;
     use crate::event::Event;
+    use futures_util::StreamExt;
     use std::{fs, sync::Mutex, time::Duration};
     use tempfile::TempDir;
     use tokio::{net::TcpListener, task};
+    use tokio_tungstenite::{accept_async, tungstenite::Message as TMsg};
 
     static ENV_MUTEX: Mutex<()> = Mutex::new(());
 
@@ -134,6 +261,10 @@ mod tests {
             "VERIFY_SIG",
             "RELAYS_UPSTREAM",
             "TOR_SOCKS",
+            "FILTER_AUTHORS",
+            "FILTER_KINDS",
+            "FILTER_TAG_T",
+            "FILTER_SINCE_MODE",
         ] {
             std::env::remove_var(v);
         }
@@ -187,6 +318,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn init_creates_default_env() {
+        let _g = ENV_MUTEX.lock().unwrap();
+        for v in [
+            "STORE_ROOT",
+            "BIND_HTTP",
+            "BIND_WS",
+            "VERIFY_SIG",
+            "RELAYS_UPSTREAM",
+            "TOR_SOCKS",
+            "FILTER_AUTHORS",
+            "FILTER_KINDS",
+            "FILTER_TAG_T",
+            "FILTER_SINCE_MODE",
+        ] {
+            std::env::remove_var(v);
+        }
+        let dir = TempDir::new().unwrap();
+        let env_path = dir.path().join(".env");
+        run(Cli {
+            env: env_path.to_string_lossy().into_owned(),
+            command: Commands::Init,
+        })
+        .await
+        .unwrap();
+
+        let data = fs::read_to_string(&env_path).unwrap();
+        let expected_root = dir.path().join("stonr-data");
+        assert!(data.contains(&format!("STORE_ROOT={}", expected_root.to_string_lossy())));
+        assert!(data.contains("BIND_HTTP=127.0.0.1:7777"));
+        assert!(data.contains("BIND_WS=127.0.0.1:7778"));
+        assert!(expected_root.join("events").exists());
+    }
+
+    #[tokio::test]
     async fn run_serve_starts_http() {
         let _g = ENV_MUTEX.lock().unwrap();
         for v in [
@@ -196,6 +361,10 @@ mod tests {
             "VERIFY_SIG",
             "RELAYS_UPSTREAM",
             "TOR_SOCKS",
+            "FILTER_AUTHORS",
+            "FILTER_KINDS",
+            "FILTER_TAG_T",
+            "FILTER_SINCE_MODE",
         ] {
             std::env::remove_var(v);
         }
@@ -237,6 +406,10 @@ mod tests {
             "VERIFY_SIG",
             "RELAYS_UPSTREAM",
             "TOR_SOCKS",
+            "FILTER_AUTHORS",
+            "FILTER_KINDS",
+            "FILTER_TAG_T",
+            "FILTER_SINCE_MODE",
         ] {
             std::env::remove_var(v);
         }
@@ -266,5 +439,94 @@ mod tests {
         let resp = reqwest::get(url).await.unwrap();
         assert!(resp.status().is_success());
         handle.abort();
+    }
+
+    #[tokio::test]
+    async fn mirror_add_validates_and_updates_env() {
+        let _g = ENV_MUTEX.lock().unwrap();
+        for v in [
+            "STORE_ROOT",
+            "BIND_HTTP",
+            "BIND_WS",
+            "VERIFY_SIG",
+            "RELAYS_UPSTREAM",
+            "TOR_SOCKS",
+            "FILTER_AUTHORS",
+            "FILTER_KINDS",
+            "FILTER_TAG_T",
+            "FILTER_SINCE_MODE",
+        ] {
+            std::env::remove_var(v);
+        }
+        let dir = TempDir::new().unwrap();
+        let env_file = write_env(&dir, "").await;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = task::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut ws = accept_async(stream).await.unwrap();
+            while let Some(msg) = ws.next().await {
+                if matches!(msg.unwrap(), TMsg::Close(_)) {
+                    break;
+                }
+            }
+        });
+
+        let url = format!("ws://{}", addr);
+        run(Cli {
+            env: env_file.clone(),
+            command: Commands::Mirror {
+                action: MirrorAction::Add { url: url.clone() },
+            },
+        })
+        .await
+        .unwrap();
+        server.await.unwrap();
+
+        let data = fs::read_to_string(&env_file).unwrap();
+        assert!(data.contains(&format!("RELAYS_UPSTREAM={url}")));
+    }
+
+    #[tokio::test]
+    async fn mirror_remove_updates_env() {
+        let _g = ENV_MUTEX.lock().unwrap();
+        for v in [
+            "STORE_ROOT",
+            "BIND_HTTP",
+            "BIND_WS",
+            "VERIFY_SIG",
+            "RELAYS_UPSTREAM",
+            "TOR_SOCKS",
+            "FILTER_AUTHORS",
+            "FILTER_KINDS",
+            "FILTER_TAG_T",
+            "FILTER_SINCE_MODE",
+        ] {
+            std::env::remove_var(v);
+        }
+        let dir = TempDir::new().unwrap();
+        let env_path = dir.path().join(".env");
+        let content = format!(
+            "STORE_ROOT={}\nBIND_HTTP=127.0.0.1:0\nBIND_WS=127.0.0.1:0\nVERIFY_SIG=0\nRELAYS_UPSTREAM=ws://one,ws://two\n",
+            dir.path().to_str().unwrap(),
+        );
+        fs::write(&env_path, content).unwrap();
+        let env_file = env_path.to_string_lossy().into_owned();
+
+        run(Cli {
+            env: env_file.clone(),
+            command: Commands::Mirror {
+                action: MirrorAction::Remove {
+                    url: "ws://one".into(),
+                },
+            },
+        })
+        .await
+        .unwrap();
+
+        let data = fs::read_to_string(&env_file).unwrap();
+        assert!(data.contains("RELAYS_UPSTREAM=ws://two"));
+        assert!(!data.contains("ws://one"));
     }
 }

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -134,6 +134,17 @@ async fn connect_ws(
     Ok(ws)
 }
 
+/// Attempt a lightweight connection to a relay to ensure it is reachable.
+///
+/// Establishes a WebSocket, immediately closes it, and returns any encountered
+/// network or handshake error to the caller so the CLI can surface failures
+/// before persisting configuration.
+pub async fn test_connection(relay: &str, tor_socks: Option<&str>) -> Result<()> {
+    let mut ws = connect_ws(relay, tor_socks).await?;
+    ws.close(None).await?;
+    Ok(())
+}
+
 /// Blanket trait for boxed async read/write streams.
 ///
 /// `TcpStream` and `Socks5Stream` implement the standard `AsyncRead` and

--- a/src/server.rs
+++ b/src/server.rs
@@ -462,8 +462,7 @@ mod tests {
                         if attempts >= MAX_ATTEMPTS {
                             panic!(
                                 "failed to fetch health endpoint after {} retries: {:?}",
-                                attempts,
-                                err
+                                attempts, err
                             );
                         }
                         tokio::time::sleep(Duration::from_millis(RETRY_DELAY_MS)).await;


### PR DESCRIPTION
## Summary
- add `stonr mirror` subcommands to add and remove upstream relays only after verifying connectivity
- persist mirror changes back to the env file and document the workflow across the README, spec, and release checklist
- cover the new commands with unit tests for both adding and removing mirrors

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68db7db6aa5c8320b73c54745293395f