### PR TITLE
Restore NixOS standalone build artifact

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -19,9 +19,25 @@ jobs:
       - name: Build release binary
         run: cargo build --locked --release
 
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+
+      - name: Build NixOS standalone binary
+        run: |
+          nix-build nix/standalone.nix
+          mkdir -p artifacts
+          cp -L result/bin/stonr artifacts/stonr-nixos-amd64
+
       - name: Upload release binary
         uses: actions/upload-artifact@v4
         with:
           name: stonr-linux-amd64
           path: target/release/stonr
+          if-no-files-found: error
+
+      - name: Upload NixOS standalone binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: stonr-nixos-amd64
+          path: artifacts/stonr-nixos-amd64
           if-no-files-found: error

--- a/nix/standalone.nix
+++ b/nix/standalone.nix
@@ -1,0 +1,18 @@
+{ pkgs ? import <nixpkgs> {} }:
+let
+  src = pkgs.lib.cleanSourceWith {
+    src = ../.;
+    filter = pkgs.lib.cleanSourceFilter;
+  };
+in pkgs.rustPlatform.buildRustPackage {
+  pname = "stonr";
+  version = "0.1.0";
+
+  inherit src;
+  cargoLock.lockFile = ../Cargo.lock;
+
+  nativeBuildInputs = [ pkgs.pkg-config ];
+  buildInputs = [ pkgs.openssl ];
+
+  doCheck = false;
+}


### PR DESCRIPTION
## Summary
- add a Nix derivation that builds the stonr release binary
- update the release workflow to build and upload the NixOS standalone artifact alongside the cargo build

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68dbab15e71c8320a748455d60820d9b