### PR TITLE
Gate release build on tests and pin Nixpkgs

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,17 +1,23 @@
 name: Build release binary
 
 on:
-  pull_request:
-    branches:
-      - '**'
+  workflow_run:
+    workflows:
+      - Test and coverage
+    types:
+      - completed
 
 jobs:
   build:
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -19,9 +25,25 @@ jobs:
       - name: Build release binary
         run: cargo build --locked --release
 
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+
+      - name: Build NixOS standalone binary
+        run: |
+          nix-build nix/standalone.nix --out-link result-nixos
+          mkdir -p artifacts
+          cp -L result-nixos/bin/stonr artifacts/stonr-nixos-amd64
+
       - name: Upload release binary
         uses: actions/upload-artifact@v4
         with:
           name: stonr-linux-amd64
           path: target/release/stonr
+          if-no-files-found: error
+
+      - name: Upload NixOS standalone binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: stonr-nixos-amd64
+          path: artifacts/stonr-nixos-amd64
           if-no-files-found: error

--- a/nix/standalone.nix
+++ b/nix/standalone.nix
@@ -1,0 +1,19 @@
+{ pkgs ? import (builtins.fetchTarball "https://channels.nixos.org/nixos-23.11/nixexprs.tar.xz") {} }:
+let
+  lib = pkgs.lib;
+  src = lib.cleanSourceWith {
+    src = ../.;
+    filter = lib.cleanSourceFilter;
+  };
+in pkgs.rustPlatform.buildRustPackage {
+  pname = "stonr";
+  version = "0.1.0";
+
+  inherit src;
+  cargoLock.lockFile = ../Cargo.lock;
+
+  nativeBuildInputs = [ pkgs.pkg-config ];
+  buildInputs = [ pkgs.openssl ];
+
+  doCheck = false;
+}


### PR DESCRIPTION
## Summary
- gate the release build workflow so it runs after the Test and coverage workflow succeeds and checks out the tested commit before building both artifacts
- pin the standalone Nix derivation to the nixos-23.11 channel tarball and cleanly copy the resulting binary from a dedicated out-link

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68dbab15e71c8320a748455d60820d9b