### PR TITLE
Use nixos-24.05 channel for standalone build

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -19,9 +19,25 @@ jobs:
       - name: Build release binary
         run: cargo build --locked --release
 
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+
+      - name: Build NixOS standalone binary
+        run: |
+          nix-build nix/standalone.nix --out-link result-nixos
+          mkdir -p artifacts
+          cp -L result-nixos/bin/stonr artifacts/stonr-nixos-amd64
+
       - name: Upload release binary
         uses: actions/upload-artifact@v4
         with:
           name: stonr-linux-amd64
           path: target/release/stonr
+          if-no-files-found: error
+
+      - name: Upload NixOS standalone binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: stonr-nixos-amd64
+          path: artifacts/stonr-nixos-amd64
           if-no-files-found: error

--- a/nix/standalone.nix
+++ b/nix/standalone.nix
@@ -1,0 +1,23 @@
+{ pkgs ? import (builtins.fetchTarball "https://channels.nixos.org/nixos-24.05/nixexprs.tar.xz") {
+    config.allowUnfree = true;
+  }
+}:
+let
+  lib = pkgs.lib;
+  rustPlatform = pkgs.rustPlatform;
+  src = lib.cleanSourceWith {
+    src = ../.;
+    filter = lib.cleanSourceFilter;
+  };
+in rustPlatform.buildRustPackage {
+  pname = "stonr";
+  version = "0.1.0";
+
+  inherit src;
+  cargoLock.lockFile = ../Cargo.lock;
+
+  nativeBuildInputs = [ pkgs.pkg-config ];
+  buildInputs = [ pkgs.openssl ];
+
+  doCheck = false;
+}


### PR DESCRIPTION
## Summary
- import the nixos-24.05 channel in the standalone Nix derivation and build with the default rustPlatform so the newer Cargo.lock format is supported

## Testing
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68dbab15e71c8320a748455d60820d9b