### PR TITLE
Pin standalone Nix build to Rust 1.75

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -19,9 +19,25 @@ jobs:
       - name: Build release binary
         run: cargo build --locked --release
 
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+
+      - name: Build NixOS standalone binary
+        run: |
+          nix-build nix/standalone.nix --out-link result-nixos
+          mkdir -p artifacts
+          cp -L result-nixos/bin/stonr artifacts/stonr-nixos-amd64
+
       - name: Upload release binary
         uses: actions/upload-artifact@v4
         with:
           name: stonr-linux-amd64
           path: target/release/stonr
+          if-no-files-found: error
+
+      - name: Upload NixOS standalone binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: stonr-nixos-amd64
+          path: artifacts/stonr-nixos-amd64
           if-no-files-found: error

--- a/nix/standalone.nix
+++ b/nix/standalone.nix
@@ -1,0 +1,38 @@
+{ pkgs ?
+    import (builtins.fetchTarball {
+      url = "https://channels.nixos.org/nixos-24.05/nixexprs.tar.xz";
+      sha256 = "1b9gsgxmfnhcccydy6px56b4pbf79dzb7h9d6m6bqmpqg3l7fzyn";
+    }) {
+      config.allowUnfree = true;
+      overlays = [
+        (import (builtins.fetchTarball {
+          url = "https://github.com/oxalica/rust-overlay/archive/refs/tags/snapshot/2025-01-11.tar.gz";
+          sha256 = "0m6z426x5fxhd5ibjg07jf3bil6z2vf9y6w2hkq28bwf2p6gyv4c";
+        }))
+      ];
+    }
+}:
+let
+  lib = pkgs.lib;
+  rustToolchain = pkgs.rust-bin.stable."1.75.0";
+  rustPlatform = pkgs.makeRustPlatform {
+    cargo = rustToolchain.cargo;
+    rustc = rustToolchain.rustc;
+  };
+  src = lib.cleanSourceWith {
+    src = ../.;
+    filter = lib.cleanSourceFilter;
+  };
+in
+rustPlatform.buildRustPackage {
+  pname = "stonr";
+  version = "0.1.0";
+
+  inherit src;
+  cargoLock.lockFile = ../Cargo.lock;
+
+  nativeBuildInputs = [ pkgs.pkg-config ];
+  buildInputs = [ pkgs.openssl ];
+
+  doCheck = false;
+}


### PR DESCRIPTION
## Summary
- pin the standalone Nix derivation to the nixos-24.05 channel tarball and oxalica rust overlay so it evaluates without a preconfigured NIX_PATH
- build the standalone package with the Rust 1.75 toolchain from the overlay to support the Cargo.lock v4 format during nix-build

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68dbab15e71c8320a748455d60820d9b