### PR TITLE
Fix rust overlay hash encoding

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -19,9 +19,25 @@ jobs:
       - name: Build release binary
         run: cargo build --locked --release
 
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+
+      - name: Build NixOS standalone binary
+        run: |
+          nix-build nix/standalone.nix --out-link result-nixos
+          mkdir -p artifacts
+          cp -L result-nixos/bin/stonr artifacts/stonr-nixos-amd64
+
       - name: Upload release binary
         uses: actions/upload-artifact@v4
         with:
           name: stonr-linux-amd64
           path: target/release/stonr
+          if-no-files-found: error
+
+      - name: Upload NixOS standalone binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: stonr-nixos-amd64
+          path: artifacts/stonr-nixos-amd64
           if-no-files-found: error

--- a/nix/standalone.nix
+++ b/nix/standalone.nix
@@ -1,0 +1,38 @@
+{ pkgs ?
+    import (builtins.fetchTarball {
+      url = "https://channels.nixos.org/nixos-24.05/nixexprs.tar.xz";
+      sha256 = "1f8j7fh0nl4qmqlxn6lis8zf7dnckm6jri4rwmj0qm1qivhr58lv";
+    }) {
+      config.allowUnfree = true;
+      overlays = [
+        (import (builtins.fetchTarball {
+          url = "https://github.com/oxalica/rust-overlay/archive/refs/tags/snapshot/2025-01-11.tar.gz";
+          sha256 = "0p8qjk100jics1y4zqffkwy1crwz78ia9ilypaasfv94qm9jdpwa";
+        }))
+      ];
+    }
+}:
+let
+  lib = pkgs.lib;
+  rustToolchain = pkgs.rust-bin.stable."1.75.0";
+  rustPlatform = pkgs.makeRustPlatform {
+    cargo = rustToolchain.cargo;
+    rustc = rustToolchain.rustc;
+  };
+  src = lib.cleanSourceWith {
+    src = ../.;
+    filter = lib.cleanSourceFilter;
+  };
+in
+rustPlatform.buildRustPackage {
+  pname = "stonr";
+  version = "0.1.0";
+
+  inherit src;
+  cargoLock.lockFile = ../Cargo.lock;
+
+  nativeBuildInputs = [ pkgs.pkg-config ];
+  buildInputs = [ pkgs.openssl ];
+
+  doCheck = false;
+}


### PR DESCRIPTION
## Summary
- encode the pinned oxalica rust-overlay tarball hash in nix/standalone.nix using the base32 form expected by nix-build

## Testing
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68dbab15e71c8320a748455d60820d9b