### PR TITLE
Document mirror subcommands in CLI help

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,34 @@ stonr mirror add-request wss://relay.example default \
 stonr mirror list
 ```
 
+### Mirror CLI reference
+
+`stonr mirror` manages both the upstream relays and the individual Nostr
+requests configured for each relay:
+
+```
+stonr mirror list                   # list configured relays and their requests
+stonr mirror add-relay <URL>        # register a relay without any requests
+stonr mirror remove-relay <URL>     # delete a relay and all of its requests
+stonr mirror list-requests <URL>    # show requests defined on a relay
+stonr mirror add-request <URL> <NAME>
+stonr mirror update-request <URL> <NAME>
+stonr mirror remove-request <URL> <NAME>
+```
+
+`add-request` and `update-request` accept a suite of Nostr filter flags so you
+can scope the mirrored data:
+
+```
+--author <PUBKEY>    repeatable author filters (hex or npub)
+--kind <KIND>        repeatable numeric kinds
+--tag <NAME=VALUE>   repeatable #t tag filters (e.g. --tag t=nostr)
+--since <TIMESTAMP>  lower UNIX timestamp bound
+--until <TIMESTAMP>  upper UNIX timestamp bound
+--limit <COUNT>      hint to limit the subscription size
+--no-cursor          disable resume cursors for the request
+```
+
 ## CLI
 
 ```

--- a/docs/mirroring.md
+++ b/docs/mirroring.md
@@ -27,6 +27,29 @@ stonr mirror list
 ```
 
 Requests can be updated or removed with `update-request` and `remove-request`.
+`stonr --help` now lists every mirror subcommand along with the filter flags
+available to `add-request` and `update-request`:
+
+```
+Mirror subcommands:
+  list                         List configured upstream relays and their requests
+  add-relay <URL>               Add a relay entry without any requests
+  remove-relay <URL>            Remove a relay and all of its requests
+  list-requests <URL>           List requests configured for a relay
+  add-request <URL> <NAME>      Create a new request on a relay
+  update-request <URL> <NAME>   Update an existing request
+  remove-request <URL> <NAME>   Remove a request from a relay
+
+Filter flags (for add-request/update-request):
+  --author <PUBKEY>             Repeatable author filters
+  --kind <KIND>                 Repeatable numeric kind filters
+  --tag <NAME=VALUE>            Repeatable #tag filters
+  --since <TIMESTAMP>           Lower UNIX timestamp bound
+  --until <TIMESTAMP>           Upper UNIX timestamp bound
+  --limit <COUNT>               Hint to limit the subscription size
+  --no-cursor                   Disable resume cursors for the request
+```
+
 All configuration is stored under `STORE_ROOT/mirror/relays/`, so changes are
 picked up automatically by a running `stonr serve` process.
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -166,4 +166,37 @@ fn cli_help_lists_commands() {
     for cmd in ["init", "ingest", "serve", "reindex", "verify", "mirror"] {
         assert!(text.contains(cmd));
     }
+    assert!(text.contains("Mirror subcommands:"));
+    assert!(text.contains("add-request"));
+    assert!(text.contains("--author <PUBKEY>"));
+}
+
+#[test]
+fn cli_help_flag_allows_scoped_help() {
+    let output = Command::cargo_bin("stonr")
+        .unwrap()
+        .args(["--help", "mirror"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8(output).unwrap();
+    assert!(text.contains("mirror"));
+    assert!(text.contains("add-relay"));
+}
+
+#[test]
+fn cli_help_subcommand_still_works() {
+    let output = Command::cargo_bin("stonr")
+        .unwrap()
+        .args(["help", "mirror"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8(output).unwrap();
+    assert!(text.contains("mirror"));
+    assert!(text.contains("add-relay"));
 }


### PR DESCRIPTION
## Summary
- surface mirror subcommands and filter flags in the global CLI help output
- document mirror management commands and filter flags in the README and mirroring guide
- extend the CLI help regression test to cover the new help text

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68dc39af8d388320ab725e073f492a84